### PR TITLE
fix: ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ jobs:
       - checkout
       - go/install:
           version: *go_version
-      - go/load-cache:
+      - go/load-mod-cache:
             key: *go_mod_cache_key
       - go/mod-download
-      - go/save-cache:
+      - go/save-mod-cache:
             key: *go_mod_cache_key
       - run: make coverage
       - codecov/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             key: *go_mod_cache_key
       - run: make coverage
       - codecov/upload:
-          file: /tmp/manifest-node-exporter-coverage/coverage-merged.out
+          files: /tmp/manifest-node-exporter-coverage/coverage-merged.out
       - run: rm coverage.html
       - go/install-goreleaser:
           version: *goreleaser_version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,8 @@ orbs:
 
 jobs:
   build:
-    executor:
-      name: ubuntu-2204
-      machine:
-        image: ubuntu-2204:current
+    machine:
+      image: ubuntu-2204:current
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
This pull request updates the caching mechanism for Go modules in the CircleCI configuration file to improve clarity and alignment with naming conventions.

### CircleCI configuration updates:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L23-R26): Renamed the `go/load-cache` step to `go/load-mod-cache` and the `go/save-cache` step to `go/save-mod-cache` to better reflect their purpose of handling Go module caches.