### PR TITLE
fix: docs and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Manifest Node Exporter
+
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/liftedinit/manifest-node-exporter/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/liftedinit/manifest-node-exporter/tree/main)
+
+A Prometheus exporter for collecting metrics from Manifest blockchain nodes.
+
+## Installation
+
+Download the latest release from the [releases page](https://github.com/liftedinit/manifest-node-exporter/releases)
+
+## Quick Start
+
+```bash
+manifest-node-exporter serve grpc-address [flags]
+```
+
+where `grpc-address` is the address of the `manifest-ledger` gRPC server.
+
+The exporter will start a Prometheus metrics server on `0.0.0.0:2112` by default.
+
+## Global Flags
+
+| Flag                | Description                                                                               |
+|---------------------|-------------------------------------------------------------------------------------------|
+| `-h`, `--help`      | help for manifest-node-exporter                                                           |
+| `-l`, `--logLevel` | Set the log level. Available levels: `debug`, `info`, `warn`, `error`. Default is `info`. |
+
+## Serve Flags
+
+| Flag                | Description                                                                               |
+|---------------------|-------------------------------------------------------------------------------------------|
+| `-h`, `--help`      | help for serve                                                                           |
+| `--insecure` | Skip TLS verification for gRPC connection. Default is `false`.                           |
+| `--listen-address` | Address to listen on for Prometheus metrics. Default is `0.0.0.0:2112`.                |
+
+## Metrics
+
+| Metric Name                         | Description                                                               |
+|-------------------------------------|---------------------------------------------------------------------------|
+| `manifest_tokenomics_denom_info`    | Information about the token denominations (symbol, denom, name, display). |  
+| `manifest_tokenomics_total_supply`  | Total supply for a given token.                                           |
+| `manifest_tokenomics_token_count`   | The number of different tokens hosted on the Manifest blockchain. |
+| `manifest_tokenomics_denom_grpc_up` | Whether the gRPC query for the token denomination was successful. |
+| `manifest_tokenomics_count_grpc_up` | Whether the gRPC query for the token count was successful. |

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -115,7 +115,6 @@ func validateGrpcAddress(grpcAddr string) error {
 
 // handleInterrupt handles interrupt signals for graceful shutdown.
 func handleInterrupt(cancel context.CancelFunc) {
-	// Handle interrupt signals for graceful shutdown
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
@@ -126,7 +125,7 @@ func handleInterrupt(cancel context.CancelFunc) {
 }
 
 func init() {
-	serveCmd.Flags().String("listen-address", ":2112", "Address to listen on")
+	serveCmd.Flags().String("listen-address", "0.0.0.0:2112", "Address to listen on")
 	serveCmd.Flags().Bool("insecure", false, "Skip TLS certificate verification (INSECURE)")
 	serveCmd.Flags().Uint("max-concurrency", 100, "Maximum request concurrency (advanced)")
 	serveCmd.Flags().Uint("max-retries", 3, "Maximum number of retries for failed requests")

--- a/pkg/collectors/grpc/token_count.go
+++ b/pkg/collectors/grpc/token_count.go
@@ -35,13 +35,13 @@ func NewTokenCountCollector(client *pkg.GRPCClient) *TokenCountCollector {
 		grpcClient:   client,
 		initialError: initialError,
 		tokenCountDesc: prometheus.NewDesc(
-			prometheus.BuildFQName("manifest", "tokenomics", "token_number"),
+			prometheus.BuildFQName("manifest", "tokenomics", "token_count"),
 			"Total number of denominations, including native, IBC and factory tokens.",
 			[]string{},
 			prometheus.Labels{"source": "grpc"},
 		),
 		upDesc: prometheus.NewDesc(
-			prometheus.BuildFQName("manifest", "tokenomics", "supply_grpc_up"),
+			prometheus.BuildFQName("manifest", "tokenomics", "count_grpc_up"),
 			"Whether the gRPC query was successful.",
 			nil,
 			prometheus.Labels{"source": "grpc", "queries": "DenomsMetadata"},

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -9,20 +9,11 @@ import (
 )
 
 type ServeConfig struct {
-	ListenAddress  string `mapstructure:"listen_address"`
-	Insecure       bool   `mapstructure:"insecure"`
-	MaxConcurrency uint   `mapstructure:"max_concurrency"`
-	MaxRetries     uint   `mapstructure:"max_retries"`
+	ListenAddress string `mapstructure:"listen_address"`
+	Insecure      bool   `mapstructure:"insecure"`
 }
 
 func (c ServeConfig) Validate() error {
-	if c.MaxConcurrency == 0 {
-		return fmt.Errorf("max-concurrency must be greater than 0")
-	}
-	if c.MaxRetries == 0 {
-		return fmt.Errorf("max-retries must be greater than 0")
-	}
-
 	host, port, err := net.SplitHostPort(c.ListenAddress)
 	if err != nil {
 		return fmt.Errorf("invalid prometheus-addr format, expected host:port: %w", err)
@@ -40,9 +31,7 @@ func (c ServeConfig) Validate() error {
 
 func LoadServeConfig() ServeConfig {
 	return ServeConfig{
-		ListenAddress:  viper.GetString("listen-address"),
-		Insecure:       viper.GetBool("insecure"),
-		MaxConcurrency: viper.GetUint("max-concurrency"),
-		MaxRetries:     viper.GetUint("max-retries"),
+		ListenAddress: viper.GetString("listen-address"),
+		Insecure:      viper.GetBool("insecure"),
 	}
 }

--- a/pkg/metrics_server.go
+++ b/pkg/metrics_server.go
@@ -48,15 +48,10 @@ func (s *MetricsServer) Start() <-chan error {
 	slog.Info("Starting Prometheus metrics server...", "address", s.listenAddr)
 
 	go func() {
-		// ListenAndServe blocks until the server stops.
 		err := s.httpServer.ListenAndServe()
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			// Only send non-nil errors that aren't the expected ErrServerClosed
 			errChan <- fmt.Errorf("prometheus metrics server failed: %w", err)
 		}
-		// Close the channel only if an error occurred, otherwise leave it open.
-		// The caller uses context cancellation for shutdown signal, not channel closing.
-		// close(errChan) // Don't close here on normal shutdown
 	}()
 
 	// Give a brief moment to allow ListenAndServe to start or fail early
@@ -77,5 +72,5 @@ func (s *MetricsServer) Shutdown(ctx context.Context) error {
 	} else {
 		slog.Error("Error during metrics server shutdown.", "error", err)
 	}
-	return err // Return the error for the caller
+	return err
 }

--- a/tests/e2e_serve_test.go
+++ b/tests/e2e_serve_test.go
@@ -53,7 +53,7 @@ func TestE2EServe(t *testing.T) {
 	}{
 		{"manifest_tokenomics_denom_info", `{denom="udummy",display="DUMMY_DISPLAY",name="Dummy_Name",source="grpc",symbol="Dummy_Symbol"}`},
 		{"manifest_tokenomics_total_supply", `{denom="udummy",source="grpc"} 10`},
-		{"manifest_tokenomics_token_number", `{source="grpc"} 102`},
+		{"manifest_tokenomics_token_count", `{source="grpc"} 102`},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a new Prometheus exporter for Manifest blockchain nodes and includes several enhancements, fixes, and cleanups across the codebase. The most significant changes include the addition of a detailed `README.md` file, updates to metric names for consistency, removal of unused configuration fields, and cleanup of redundant comments in the code.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R44): Added comprehensive documentation for the Manifest Node Exporter, including installation instructions, usage examples, global and serve flags, and a list of available metrics.

### Metric Name Updates:
* `pkg/collectors/grpc/token_count.go`: Updated metric names to align with naming conventions:
  - Changed `manifest_tokenomics_token_number` to `manifest_tokenomics_token_count`.
  - Changed `manifest_tokenomics_supply_grpc_up` to `manifest_tokenomics_count_grpc_up`.
* [`tests/e2e_serve_test.go`](diffhunk://#diff-0aac67853fd3858f4ed27f4d08a9ec53d5a92267ea7d00349e9c3daf21151240L56-R56): Updated test cases to reflect the new metric names.

### Configuration Simplifications:
* [`pkg/config.go`](diffhunk://#diff-26f0185e462eee9c623c61960b8c34d80b910e4bc4984842100f38dd1965462cL14-L25): Removed unused `MaxConcurrency` and `MaxRetries` fields from the `ServeConfig` struct and their associated validations and loading logic. [[1]](diffhunk://#diff-26f0185e462eee9c623c61960b8c34d80b910e4bc4984842100f38dd1965462cL14-L25) [[2]](diffhunk://#diff-26f0185e462eee9c623c61960b8c34d80b910e4bc4984842100f38dd1965462cL45-L46)

### Code Cleanup:
* [`cmd/serve.go`](diffhunk://#diff-fb0c696bc104f613e5b601c77c2eba916dd636d5948c9b5c8e85ea92ee5b07e6L118): Updated the default `listen-address` flag value to `0.0.0.0:2112` and removed redundant comments. [[1]](diffhunk://#diff-fb0c696bc104f613e5b601c77c2eba916dd636d5948c9b5c8e85ea92ee5b07e6L118) [[2]](diffhunk://#diff-fb0c696bc104f613e5b601c77c2eba916dd636d5948c9b5c8e85ea92ee5b07e6L129-R128)
* [`pkg/metrics_server.go`](diffhunk://#diff-b757718c6bf19aebdc26cef878813df87579d700bd18c2651a4023b7472c4e0aL51-L59): Simplified error handling in `Start` and `Shutdown` methods by removing unnecessary comments and redundant logic. [[1]](diffhunk://#diff-b757718c6bf19aebdc26cef878813df87579d700bd18c2651a4023b7472c4e0aL51-L59) [[2]](diffhunk://#diff-b757718c6bf19aebdc26cef878813df87579d700bd18c2651a4023b7472c4e0aL80-R75)
* [`pkg/collectors/grpc/registry.go`](diffhunk://#diff-44b5431d02aa5c743a8a7dffcf3a429082e6039c58ef75d55b5a7ca4c687b314L66): Cleaned up comments and removed unused code related to Prometheus collector registration. [[1]](diffhunk://#diff-44b5431d02aa5c743a8a7dffcf3a429082e6039c58ef75d55b5a7ca4c687b314L66) [[2]](diffhunk://#diff-44b5431d02aa5c743a8a7dffcf3a429082e6039c58ef75d55b5a7ca4c687b314L82-L92)