### PR TITLE
fix: big number and supply

### DIFF
--- a/pkg/collectors/autodetect/manifestd/denom_info.go
+++ b/pkg/collectors/autodetect/manifestd/denom_info.go
@@ -168,7 +168,10 @@ func (c *DenomInfoCollector) collectTotalSupply(ch chan<- prometheus.Metric, res
 		slog.Warn("Total scaled supply cannot be represented as int64")
 	}
 
-	amount, _ = resultFloat.Float64()
+	amount, exact := resultFloat.Float64()
+	if !exact {
+		slog.Warn("Inexact conversion from big.Float to float64", "denom", coin.Denom, "amount", coin.Amount)
+	}
 
 	// *IMPORTANT*
 	// The metric's metadata contains the supply of the token in the base denomination.


### PR DESCRIPTION
This pull request updates the `DenomInfoCollector` in the `manifestd` package to improve metric handling for token supply data. The key changes include the addition of a new label to metrics, the removal of amount parsing logic, and a shift in responsibility for interpreting metadata to the client.

### Metric enhancements:

* [`pkg/collectors/autodetect/manifestd/denom_info.go`](diffhunk://#diff-6f465504ec7ebce47a9e6db58fcb50d302370a08c3a08ea4f402af3d296a1bd4L53-R52): Added a new label, `"supply"`, to the `totalSupplyDesc` metric to include the token's supply amount as metadata.

### Code simplification and responsibility shift:

* [`pkg/collectors/autodetect/manifestd/denom_info.go`](diffhunk://#diff-6f465504ec7ebce47a9e6db58fcb50d302370a08c3a08ea4f402af3d296a1bd4L148-R155): Removed the logic for parsing the token amount (`strconv.ParseFloat`) and replaced it with a fixed gauge value of `1`, delegating metadata interpretation to the client. This simplifies the code and reduces potential parsing errors.

### Cleanup:

* [`pkg/collectors/autodetect/manifestd/denom_info.go`](diffhunk://#diff-6f465504ec7ebce47a9e6db58fcb50d302370a08c3a08ea4f402af3d296a1bd4L5): Removed the unused `strconv` import, as token amount parsing is no longer required.