### PR TITLE
feat: port geoip to ipbase & cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The exporter will start a Prometheus metrics server on `0.0.0.0:2112` by default
 |---------------------|-------------------------------------------------------------------------------------------|
 | `-h`, `--help`      | help for serve                                                                           |
 | `--listen-address` | Address to listen on for Prometheus metrics. Default is `0.0.0.0:2112`.                |
+| `--ipbase-key` | API key for IPBase to get geographical information. If not set, geo info will not be collected. |
+| `--state-file` | Path to the state file where the exporter will store its state. Default is `./state.json`. |
 
 ## Metrics
 

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
 github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/everapihq/ipbase-go v0.1.1 h1:EgSyxh6szXY4ZKxQYCe1+q8pTfeox8L8J7KMj2upm4g=
+github.com/everapihq/ipbase-go v0.1.1/go.mod h1:EeLWChXUEi6d6excyTeUH66Upu6WH2sCOcVNibuqSuw=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
 github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/everapihq/ipbase-go v0.1.1 h1:EgSyxh6szXY4ZKxQYCe1+q8pTfeox8L8J7KMj2upm4g=
-github.com/everapihq/ipbase-go v0.1.1/go.mod h1:EeLWChXUEi6d6excyTeUH66Upu6WH2sCOcVNibuqSuw=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -10,6 +10,8 @@ import (
 
 type ServeConfig struct {
 	ListenAddress string `mapstructure:"listen_address"`
+	IpBaseKey     string `mapstructure:"ipbase_key"`
+	StateFile     string `mapstructure:"state_file"`
 }
 
 func (c ServeConfig) Validate() error {
@@ -25,11 +27,17 @@ func (c ServeConfig) Validate() error {
 		return fmt.Errorf("invalid host in prometheus-addr: %s", host)
 	}
 
+	if c.StateFile == "" {
+		return fmt.Errorf("state-file must be specified")
+	}
+
 	return nil
 }
 
 func LoadServeConfig() ServeConfig {
 	return ServeConfig{
 		ListenAddress: viper.GetString("listen-address"),
+		IpBaseKey:     viper.GetString("ipbase-key"),
+		StateFile:     viper.GetString("state-file"),
 	}
 }


### PR DESCRIPTION
This pull request introduces enhancements to the GeoIP functionality of the Prometheus exporter, including the integration of IPBase for GeoIP lookups, state persistence for caching, and improved configuration options. The most important changes are grouped below by theme.

### GeoIP Enhancements:
* Updated `GeoIPCollector` to support IPBase API integration by adding an `ipbase-key` parameter and refactoring the `getGeoIP` function to use the IPBase API. [[1]](diffhunk://#diff-4ddeca70cd83427138a617f3f9a6f794f4fc3365de92ea3c9b4afd68b26a1c55R25-R91) [[2]](diffhunk://#diff-4ddeca70cd83427138a617f3f9a6f794f4fc3365de92ea3c9b4afd68b26a1c55L149-R234)
* Added caching functionality to `GeoIPCollector`, enabling state persistence for GeoIP data with a configurable `state-file` parameter. This includes methods to load and save state, and logic to refresh data based on cache expiration. [[1]](diffhunk://#diff-4ddeca70cd83427138a617f3f9a6f794f4fc3365de92ea3c9b4afd68b26a1c55R113-R136) [[2]](diffhunk://#diff-4ddeca70cd83427138a617f3f9a6f794f4fc3365de92ea3c9b4afd68b26a1c55L86-R190)

### Configuration Updates:
* Added new flags `--ipbase-key` and `--state-file` to the `serve` command for configuring the IPBase API key and state file path, respectively.
* Updated `ServeConfig` to include `IpBaseKey` and `StateFile` fields, with validation to ensure `state-file` is specified. [[1]](diffhunk://#diff-26f0185e462eee9c623c61960b8c34d80b910e4bc4984842100f38dd1965462cR13-R14) [[2]](diffhunk://#diff-26f0185e462eee9c623c61960b8c34d80b910e4bc4984842100f38dd1965462cR30-R41)

### Code Refactoring:
* Refactored the GeoIP data structures to align with the IPBase API response, introducing new types such as `GeoIPResponse`, `GeoIPData`, and `GeoIPLocation`.
* Replaced hardcoded FreeGeoIP URL with IPBase API endpoint in `getGeoIP`.

### Documentation:
* Updated `README.md` to document the new `--ipbase-key` and `--state-file` flags.