### PR TITLE
ci: disable docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ jobs:
       - checkout
       - go/install:
           version: *go_version
-      - go/load-cache:
+      - go/load-mod-cache:
             key: *go_mod_cache_key
       - go/mod-download
-      - go/save-cache:
+      - go/save-mod-cache:
             key: *go_mod_cache_key
       - run: make coverage
       - codecov/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ GO_MOD_CACHE_KEY: &go_mod_cache_key 'go-mod-1'
 orbs:
   go: circleci/go@3.0.2
   codecov: codecov/codecov@5.3.0
-  docker: circleci/docker@2.8.2
+#  docker: circleci/docker@2.8.2
 
 jobs:
   build:
@@ -83,15 +83,15 @@ workflows:
     jobs:
       - build
       - security
-  docker:
-    jobs:
-      - docker:
-          context:
-            - DOCKER_CREDS
-          filters:
-            branches:
-              only:
-                - main
+#  docker:
+#    jobs:
+#      - docker:
+#          context:
+#            - DOCKER_CREDS
+#          filters:
+#            branches:
+#              only:
+#                - main
   release:
     jobs:
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             key: *go_mod_cache_key
       - run: make coverage
       - codecov/upload:
-          file: /tmp/manifest-node-exporter-coverage/coverage-merged.out
+          files: /tmp/manifest-node-exporter-coverage/coverage-merged.out
       - run: rm coverage.html
       - go/install-goreleaser:
           version: *goreleaser_version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,23 +38,23 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
-  docker:
-    executor: docker/docker
-    steps:
-      - setup_remote_docker
-      - checkout
-      - docker/check
-      - docker/build:
-          image: lifted/manifest-node-exporter
-          tag: "latest,${CIRCLE_SHA1}"
-      - docker/push:
-          digest-path: /tmp/digest.txt
-          image: lifted/manifest-node-exporter
-          tag: "latest,${CIRCLE_SHA1}"
-      - run:
-          command: |
-            echo "Digest is: $(</tmp/digest.txt)"
-
+#  docker:
+#    executor: docker/docker
+#    steps:
+#      - setup_remote_docker
+#      - checkout
+#      - docker/check
+#      - docker/build:
+#          image: lifted/manifest-node-exporter
+#          tag: "latest,${CIRCLE_SHA1}"
+#      - docker/push:
+#          digest-path: /tmp/digest.txt
+#          image: lifted/manifest-node-exporter
+#          tag: "latest,${CIRCLE_SHA1}"
+#      - run:
+#          command: |
+#            echo "Digest is: $(</tmp/digest.txt)"
+#
   security:
     executor:
       name: go/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,8 @@ orbs:
 
 jobs:
   build:
-    executor:
-      name: ubuntu-2204
-      machine:
-        image: ubuntu-2204:current
+    machine:
+      image: ubuntu-2204:current
     resource_class: large
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-GO_VERSION: &go_version '1.24.2'
+GO_VERSION: &go_version '1.24.4'
 GORELEASER_VERSION: &goreleaser_version 'v2.9.0'
 GO_MOD_CACHE_KEY: &go_mod_cache_key 'go-mod-1'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liftedinit/manifest-node-exporter
 
-go 1.24.2
+go 1.24.4
 
 require (
 	cosmossdk.io/api v0.9.2


### PR DESCRIPTION
This pull request modifies the `.circleci/config.yml` file to deprecate the use of the Docker job and related steps while updating the Go module cache handling. The changes streamline the CI configuration by focusing on Go-related tasks and removing Docker-related functionality.

### Deprecation of Docker-related functionality:
* Commented out the `docker` orb and all associated steps, including building, pushing, and tagging Docker images, as well as storing Docker-related artifacts. This includes the removal of the `docker` job from workflows and its branch filters. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L10-R28) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L43-R57) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L88-R94)

### Updates to Go module cache handling:
* Replaced `go/load-cache` and `go/save-cache` steps with `go/load-mod-cache` and `go/save-mod-cache` to align with updated Go module caching practices.