### PR TITLE
feat: fee cache

### DIFF
--- a/pkg/collectors/autodetect/manifestd/fees.go
+++ b/pkg/collectors/autodetect/manifestd/fees.go
@@ -5,8 +5,14 @@ package manifestd
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"log/slog"
 	"math/big"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	distributionv1beta1 "cosmossdk.io/api/cosmos/distribution/v1beta1"
@@ -24,8 +30,30 @@ type FeesCollector struct {
 	grpcClient   *client.GRPCClient
 	feesDesc     *prometheus.Desc
 	upDesc       *prometheus.Desc
+	errorsDesc   *prometheus.Desc
 	denom        string
 	initialError error
+
+	cache     map[string]math.Int
+	cacheMu   sync.RWMutex
+	stateFile string
+
+	validatorErrsTotal uint64
+}
+
+type feesState map[string]string
+
+func defaultFeesStatePath(denom string) string {
+	base, err := os.UserCacheDir()
+	if err != nil || base == "" {
+		home, _ := os.UserHomeDir()
+		if home == "" {
+			base = "."
+		} else {
+			base = filepath.Join(home, ".cache")
+		}
+	}
+	return filepath.Join(base, "manifest-node-exporter", "fees_"+denom+".json")
 }
 
 func NewFeesCollector(client *client.GRPCClient, denom string) *FeesCollector {
@@ -36,10 +64,13 @@ func NewFeesCollector(client *client.GRPCClient, denom string) *FeesCollector {
 		initialError = status.Error(codes.Internal, "gRPC client connection is nil")
 	}
 
-	return &FeesCollector{
-		grpcClient:   client,
-		initialError: initialError,
-		denom:        denom,
+	c := &FeesCollector{
+		grpcClient:         client,
+		initialError:       initialError,
+		validatorErrsTotal: 0,
+		denom:              denom,
+		cache:              make(map[string]math.Int),
+		stateFile:          defaultFeesStatePath(denom),
 		feesDesc: prometheus.NewDesc(
 			prometheus.BuildFQName("manifest", "tokenomics", "fees"),
 			"Transaction fees locked in validators.",
@@ -52,19 +83,123 @@ func NewFeesCollector(client *client.GRPCClient, denom string) *FeesCollector {
 			nil,
 			prometheus.Labels{"source": "grpc", "queries": "Validators, ValidatorOutstandingRewards"},
 		),
+		errorsDesc: prometheus.NewDesc(
+			prometheus.BuildFQName("manifest", "tokenomics", "fees_validator_failures_total"),
+			"Total per-validator gRPC failures since process start.",
+			nil,
+			prometheus.Labels{"source": "grpc", "denom": denom},
+		),
 	}
+
+	if err := c.loadState(); err != nil {
+		slog.Warn("failed to load fees cache", "path", c.stateFile, "error", err)
+	}
+
+	return c
+}
+
+func (c *FeesCollector) loadState() error {
+	b, err := os.ReadFile(c.stateFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	var st feesState
+	if err := json.Unmarshal(b, &st); err != nil {
+		return err
+	}
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+	for addr, s := range st {
+		if v, ok := math.NewIntFromString(s); ok {
+			c.cache[addr] = v
+		}
+	}
+	return nil
+}
+
+func (c *FeesCollector) saveState() error {
+	// snapshot cache under read lock
+	c.cacheMu.RLock()
+	st := make(feesState, len(c.cache))
+	for addr, v := range c.cache {
+		st[addr] = v.String()
+	}
+	c.cacheMu.RUnlock()
+
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(c.stateFile), 0o755); err != nil {
+		return err
+	}
+	tmp := c.stateFile + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, c.stateFile)
+}
+
+func (c *FeesCollector) emitUpAndErrors(ch chan<- prometheus.Metric, up float64) {
+	collectors.ReportUpMetric(ch, c.upDesc, up)
+
+	failures := atomic.LoadUint64(&c.validatorErrsTotal)
+	errMetric, err := prometheus.NewConstMetric(c.errorsDesc, prometheus.CounterValue, float64(failures))
+	if err != nil {
+		slog.Error("failed to create validator failure metric", "error", err)
+		collectors.ReportInvalidMetric(ch, c.errorsDesc, err)
+		return
+	}
+	ch <- errMetric
+}
+
+func (c *FeesCollector) emitFromDisk(ch chan<- prometheus.Metric, up float64) {
+	c.emitUpAndErrors(ch, up)
+
+	b, err := os.ReadFile(c.stateFile)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("failed to read fees cache from disk", "path", c.stateFile, "error", err)
+		}
+		return
+	}
+
+	var st feesState
+	if err := json.Unmarshal(b, &st); err != nil {
+		slog.Warn("failed to unmarshal fees cache from disk", "path", c.stateFile, "error", err)
+		return
+	}
+
+	total := math.ZeroInt()
+	for _, s := range st {
+		if v, ok := math.NewIntFromString(s); ok {
+			total = total.Add(v)
+		}
+	}
+
+	m, err := prometheus.NewConstMetric(c.feesDesc, prometheus.GaugeValue, 1, total.String(), c.denom)
+	if err != nil {
+		slog.Error("failed to create fees metric", "error", err)
+		collectors.ReportInvalidMetric(ch, c.feesDesc, err)
+		return
+	}
+	ch <- m
 }
 
 func (c *FeesCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.feesDesc
 	ch <- c.upDesc
+	ch <- c.errorsDesc
 }
 
 func (c *FeesCollector) Collect(ch chan<- prometheus.Metric) {
 	// Check for initialization or connection errors first.
 	if err := collectors.ValidateClient(c.grpcClient, c.initialError); err != nil {
-		collectors.ReportUpMetric(ch, c.upDesc, 0) // Report gRPC down
-		collectors.ReportInvalidMetric(ch, c.feesDesc, err)
+		c.emitFromDisk(ch, 0)
 		return
 	}
 
@@ -72,21 +207,27 @@ func (c *FeesCollector) Collect(ch chan<- prometheus.Metric) {
 	validatorsResp, validatorsErr := stakingQueryClient.Validators(c.grpcClient.Ctx, &stakingv1beta1.QueryValidatorsRequest{})
 	if validatorsErr != nil {
 		slog.Error("Failed to query via gRPC", "query", "Validators", "error", validatorsErr)
-		collectors.ReportUpMetric(ch, c.upDesc, 0)
-		collectors.ReportInvalidMetric(ch, c.feesDesc, validatorsErr)
+		c.emitFromDisk(ch, 0)
 		return
 	}
 
-	if validatorsResp == nil || validatorsResp.Validators == nil || len(validatorsResp.Validators) == 0 {
-		collectors.ReportUpMetric(ch, c.upDesc, 0)
-		collectors.ReportInvalidMetric(ch, c.feesDesc, status.Error(codes.Internal, "Validators response is nil or empty"))
+	if validatorsResp == nil || validatorsResp.Validators == nil {
+		slog.Error("Validators response is nil")
+		c.emitFromDisk(ch, 0)
 		return
 	}
 
 	distributionQueryClient := distributionv1beta1.NewQueryClient(c.grpcClient.Conn)
 	const rpcTimeout = 2 * time.Second
-	eg, egCtx := errgroup.WithContext(c.grpcClient.Ctx)
-	results := make(chan math.Int, len(validatorsResp.Validators))
+
+	var (
+		eg, egCtx  = errgroup.WithContext(c.grpcClient.Ctx)
+		mu         sync.Mutex
+		updates    = make(map[string]math.Int)
+		scrapeErrs uint64
+	)
+
+	//results := make(chan math.Int, len(validatorsResp.Validators))
 	for _, val := range validatorsResp.Validators {
 		val := val
 		eg.Go(func() error {
@@ -96,27 +237,32 @@ func (c *FeesCollector) Collect(ch chan<- prometheus.Metric) {
 			feesResp, feesErr := distributionQueryClient.ValidatorOutstandingRewards(callCtx, &distributionv1beta1.QueryValidatorOutstandingRewardsRequest{ValidatorAddress: val.OperatorAddress})
 			if feesErr != nil {
 				slog.Error("Failed to query via gRPC", "query", "ValidatorOutstandingRewards", "validator", val.OperatorAddress, "error", feesErr)
-				return feesErr
+				atomic.AddUint64(&scrapeErrs, 1)
+				return nil
 			}
 			if feesResp == nil || feesResp.Rewards == nil {
 				slog.Error("ValidatorOutstandingRewards response is nil or empty", "validator", val.OperatorAddress)
-				return status.Error(codes.Internal, "ValidatorOutstandingRewards response is nil or empty")
+				atomic.AddUint64(&scrapeErrs, 1)
+				return nil
 			}
 			if len(feesResp.Rewards.Rewards) != 1 {
 				slog.Warn("ValidatorOutstandingRewards response has no rewards or too many rewards", "validator", val.OperatorAddress)
 				return nil
 			}
+
 			denom := feesResp.Rewards.Rewards[0].Denom
 			if denom != c.denom {
 				slog.Warn("ValidatorOutstandingRewards response has different denom", "validator", val.OperatorAddress, "expected", c.denom, "got", denom)
-				return status.Error(codes.InvalidArgument, "denom mismatch for validator "+val.OperatorAddress+": expected "+c.denom+", got "+denom)
+				atomic.AddUint64(&scrapeErrs, 1)
+				return nil
 			}
 
 			// Convert the amount to a big.Int
 			amount, ok := new(big.Int).SetString(feesResp.Rewards.Rewards[0].Amount, 10)
 			if !ok {
 				slog.Error("Failed to parse coin amount", "validator", val.OperatorAddress, "amount", feesResp.Rewards.Rewards[0].Amount)
-				return status.Error(codes.Internal, "invalid coin amount for validator "+val.OperatorAddress+": "+feesResp.Rewards.Rewards[0].Amount)
+				atomic.AddUint64(&scrapeErrs, 1)
+				return nil
 			}
 
 			// And create a LegacyDec from it, using the LegacyPrecision
@@ -124,33 +270,38 @@ func (c *FeesCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// And only keep the integer part
 			truncatedAmount := legacyAmount.TruncateInt()
-			results <- truncatedAmount
+			mu.Lock()
+			updates[val.OperatorAddress] = truncatedAmount
+			mu.Unlock()
 
 			return nil
 		})
 	}
 
-	if err := eg.Wait(); err != nil {
-		collectors.ReportUpMetric(ch, c.upDesc, 0)
-		collectors.ReportInvalidMetric(ch, c.feesDesc, err)
-		close(results)
-		return
-	}
-	close(results)
+	_ = eg.Wait()
 
-	total := math.ZeroInt()
-	for v := range results {
-		total = total.Add(v)
+	if n := atomic.LoadUint64(&scrapeErrs); n > 0 {
+		atomic.AddUint64(&c.validatorErrsTotal, n)
 	}
 
-	collectors.ReportUpMetric(ch, c.upDesc, 1)
-	m, err := prometheus.NewConstMetric(c.feesDesc, prometheus.GaugeValue, 1, total.String(), c.denom)
-	if err != nil {
-		slog.Error("Failed to create fees metric", "error", err)
-		collectors.ReportInvalidMetric(ch, c.feesDesc, err)
-	} else {
-		ch <- m
+	var changed bool
+	c.cacheMu.Lock()
+	for addr, amt := range updates {
+		prev, ok := c.cache[addr]
+		if !ok || !prev.Equal(amt) {
+			c.cache[addr] = amt
+			changed = true
+		}
 	}
+	c.cacheMu.Unlock()
+
+	if changed {
+		if err := c.saveState(); err != nil {
+			slog.Warn("failed to persist fees cache", "path", c.stateFile, "error", err)
+		}
+	}
+
+	c.emitFromDisk(ch, 1)
 }
 
 func init() {

--- a/pkg/collectors/autodetect/manifestd/fees.go
+++ b/pkg/collectors/autodetect/manifestd/fees.go
@@ -277,9 +277,7 @@ func (c *FeesCollector) Collect(ch chan<- prometheus.Metric) {
 		})
 	}
 
-	if err := eg.Wait(); err != nil {
-		slog.Warn("error waiting for validator goroutines", "error", err)
-	}
+	_ = eg.Wait()
 
 	if n := atomic.LoadUint64(&scrapeErrs); n > 0 {
 		atomic.AddUint64(&c.validatorErrsTotal, n)

--- a/pkg/collectors/autodetect/manifestd/fees.go
+++ b/pkg/collectors/autodetect/manifestd/fees.go
@@ -227,7 +227,6 @@ func (c *FeesCollector) Collect(ch chan<- prometheus.Metric) {
 		scrapeErrs uint64
 	)
 
-	//results := make(chan math.Int, len(validatorsResp.Validators))
 	for _, val := range validatorsResp.Validators {
 		val := val
 		eg.Go(func() error {
@@ -278,7 +277,9 @@ func (c *FeesCollector) Collect(ch chan<- prometheus.Metric) {
 		})
 	}
 
-	_ = eg.Wait()
+	if err := eg.Wait(); err != nil {
+		slog.Warn("error waiting for validator goroutines", "error", err)
+	}
 
 	if n := atomic.LoadUint64(&scrapeErrs); n > 0 {
 		atomic.AddUint64(&c.validatorErrsTotal, n)


### PR DESCRIPTION
This pull request introduces persistent caching and improved error handling to the `FeesCollector` in `pkg/collectors/autodetect/manifestd/fees.go`. The main goal is to ensure fee data is retained across process restarts and that per-validator gRPC failures are tracked and reported. The changes add a disk-backed cache for fee data, a new Prometheus metric for validator errors, and refactor the collection logic to use these new capabilities.

### Persistent fee caching and state management
* Added a disk-backed cache (`cache` and `stateFile`) to store per-validator fee data, with functions to load and save state (`loadState`, `saveState`). This ensures fee data is preserved across restarts. [[1]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4R33-R56) [[2]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4L39-R73) [[3]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4R86-R230)

### Enhanced error tracking and metrics
* Introduced a new Prometheus metric (`errorsDesc`) to track total per-validator gRPC failures, and updated error handling to increment this counter on failures instead of aborting the scrape. [[1]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4R33-R56) [[2]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4R86-R230) [[3]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4L99-R306)

### Refactored collection logic
* Refactored the `Collect` method to use the disk cache for reporting metrics when gRPC is down or returns errors, and to update the cache only when fee data changes. [[1]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4R86-R230) [[2]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4L99-R306)

### Thread safety improvements
* Added mutexes and atomic counters to ensure thread-safe updates to the cache and error counters during concurrent metric collection. [[1]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4R33-R56) [[2]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4L99-R306)

### Improved robustness and logging
* Improved logging for error cases, including cache load/save failures and metric creation errors, making the collector more robust and easier to debug. [[1]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4R86-R230) [[2]](diffhunk://#diff-13a1a129c87e3d9995d358ce0d1aa0d642eeb0b935ec618c7fe4ee5487ffb0a4L99-R306)