### PR TITLE
fix: sum umfx component of multi-denom validator rewards (ENG-283)

### DIFF
--- a/pkg/collectors/autodetect/manifestd/fees.go
+++ b/pkg/collectors/autodetect/manifestd/fees.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"time"
 
+	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
 	distributionv1beta1 "cosmossdk.io/api/cosmos/distribution/v1beta1"
 	stakingv1beta1 "cosmossdk.io/api/cosmos/staking/v1beta1"
 	"cosmossdk.io/math"
@@ -53,6 +54,28 @@ func NewFeesCollector(client *client.GRPCClient, denom string) *FeesCollector {
 			prometheus.Labels{"source": "grpc", "queries": "Validators, ValidatorOutstandingRewards"},
 		),
 	}
+}
+
+// extractDenomRewards sums the `denom` component of a validator's outstanding
+// rewards. Outstanding rewards are DecCoins and may hold multiple denoms (e.g.
+// umfx + PWR/upwr after billing v2), so we pick out only the requested denom and
+// ignore the rest. Validators with no matching reward contribute zero.
+func extractDenomRewards(rewards []*basev1beta1.DecCoin, denom, validatorAddr string) (math.Int, error) {
+	for _, coin := range rewards {
+		if coin.Denom != denom {
+			continue
+		}
+		// Convert the amount to a big.Int.
+		amount, ok := new(big.Int).SetString(coin.Amount, 10)
+		if !ok {
+			slog.Error("Failed to parse coin amount", "validator", validatorAddr, "amount", coin.Amount)
+			return math.ZeroInt(), status.Error(codes.Internal, "invalid coin amount for validator "+validatorAddr+": "+coin.Amount)
+		}
+		// Build a LegacyDec using LegacyPrecision and keep only the integer part.
+		// DecCoins hold at most one entry per denom, so we can return immediately.
+		return math.LegacyNewDecFromBigIntWithPrec(amount, math.LegacyPrecision).TruncateInt(), nil
+	}
+	return math.ZeroInt(), nil
 }
 
 func (c *FeesCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -102,29 +125,15 @@ func (c *FeesCollector) Collect(ch chan<- prometheus.Metric) {
 				slog.Error("ValidatorOutstandingRewards response is nil or empty", "validator", val.OperatorAddress)
 				return status.Error(codes.Internal, "ValidatorOutstandingRewards response is nil or empty")
 			}
-			if len(feesResp.Rewards.Rewards) != 1 {
-				slog.Warn("ValidatorOutstandingRewards response has no rewards or too many rewards", "validator", val.OperatorAddress)
-				return nil
-			}
-			denom := feesResp.Rewards.Rewards[0].Denom
-			if denom != c.denom {
-				slog.Warn("ValidatorOutstandingRewards response has different denom", "validator", val.OperatorAddress, "expected", c.denom, "got", denom)
-				return status.Error(codes.InvalidArgument, "denom mismatch for validator "+val.OperatorAddress+": expected "+c.denom+", got "+denom)
-			}
 
-			// Convert the amount to a big.Int
-			amount, ok := new(big.Int).SetString(feesResp.Rewards.Rewards[0].Amount, 10)
-			if !ok {
-				slog.Error("Failed to parse coin amount", "validator", val.OperatorAddress, "amount", feesResp.Rewards.Rewards[0].Amount)
-				return status.Error(codes.Internal, "invalid coin amount for validator "+val.OperatorAddress+": "+feesResp.Rewards.Rewards[0].Amount)
+			// Outstanding rewards may hold multiple denoms (e.g. umfx + PWR/upwr
+			// after billing v2); sum only the c.denom component. Validators with
+			// no matching reward contribute zero.
+			amount, err := extractDenomRewards(feesResp.Rewards.Rewards, c.denom, val.OperatorAddress)
+			if err != nil {
+				return err
 			}
-
-			// And create a LegacyDec from it, using the LegacyPrecision
-			legacyAmount := math.LegacyNewDecFromBigIntWithPrec(amount, math.LegacyPrecision)
-
-			// And only keep the integer part
-			truncatedAmount := legacyAmount.TruncateInt()
-			results <- truncatedAmount
+			results <- amount
 
 			return nil
 		})

--- a/pkg/collectors/autodetect/manifestd/fees_test.go
+++ b/pkg/collectors/autodetect/manifestd/fees_test.go
@@ -1,0 +1,91 @@
+//go:build manifest_node_exporter
+// +build manifest_node_exporter
+
+package manifestd
+
+import (
+	"testing"
+
+	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
+	"cosmossdk.io/math"
+)
+
+// decCoin builds a reward coin. Outstanding-reward amounts are LegacyDec values
+// serialized as integers scaled by 10^18 (math.LegacyPrecision), matching what
+// the distribution module returns for ValidatorOutstandingRewards.
+func decCoin(denom, amount string) *basev1beta1.DecCoin {
+	return &basev1beta1.DecCoin{Denom: denom, Amount: amount}
+}
+
+const (
+	testDenomUMFX = "umfx"
+	// Representative billing-v2 PWR denom that appears alongside umfx.
+	testDenomUPWR = "factory/manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj/upwr"
+)
+
+func TestExtractDenomRewards(t *testing.T) {
+	// 320 and 100 expressed as LegacyDec (scaled by 10^18).
+	const umfxAmount = "320000000000000000000"
+	const upwrAmount = "100000000000000000000"
+
+	tests := []struct {
+		name    string
+		rewards []*basev1beta1.DecCoin
+		want    math.Int
+		wantErr bool
+	}{
+		{
+			name:    "multi-denom umfx and upwr returns umfx amount",
+			rewards: []*basev1beta1.DecCoin{decCoin(testDenomUMFX, umfxAmount), decCoin(testDenomUPWR, upwrAmount)},
+			want:    math.NewInt(320),
+		},
+		{
+			name:    "upwr before umfx still returns umfx amount",
+			rewards: []*basev1beta1.DecCoin{decCoin(testDenomUPWR, upwrAmount), decCoin(testDenomUMFX, umfxAmount)},
+			want:    math.NewInt(320),
+		},
+		{
+			name:    "single umfx returns umfx amount",
+			rewards: []*basev1beta1.DecCoin{decCoin(testDenomUMFX, umfxAmount)},
+			want:    math.NewInt(320),
+		},
+		{
+			name:    "fractional umfx is truncated",
+			rewards: []*basev1beta1.DecCoin{decCoin(testDenomUMFX, "320900000000000000000")},
+			want:    math.NewInt(320),
+		},
+		{
+			name:    "single upwr contributes zero",
+			rewards: []*basev1beta1.DecCoin{decCoin(testDenomUPWR, upwrAmount)},
+			want:    math.ZeroInt(),
+		},
+		{
+			name:    "empty rewards contributes zero",
+			rewards: nil,
+			want:    math.ZeroInt(),
+		},
+		{
+			name:    "invalid umfx amount errors",
+			rewards: []*basev1beta1.DecCoin{decCoin(testDenomUMFX, "not-a-number")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractDenomRewards(tt.rewards, testDenomUMFX, "manifestvaloper1test")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Fatalf("got %s, want %s", got.String(), tt.want.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The dashboard chart **"Locked MFX (fees)"** (`locked_fees`) dropped to **0.0** around **2026-06-01** and stayed there. The MFX is still locked on-chain — only the exporter's reading was wrong.

**Root cause:** `fees.go` assumed each validator's `ValidatorOutstandingRewards` was exactly one `umfx` coin:
- `if len(feesResp.Rewards.Rewards) != 1 { ... return nil }` → skipped the validator (contributed 0)
- `if denom != c.denom { ... }` → hard error

Billing v2 introduced **PWR** (`upwr`). Once the v2 lease economy went live on mainnet, `upwr`-denominated fees began routing into validator outstanding rewards, so every validator's reward set became two coins `{umfx, upwr}` → `len != 1` → every validator skipped → total summed to **0**. The clean `0.0` (vs `N/A`) fingerprinted the `len != 1` path, which `return nil`s per-validator without error.

## Fix

Replace the single-coin assumption with `extractDenomRewards`, which sums only the `c.denom` (`umfx`) component out of the now multi-denom `DecCoins` and ignores the rest. Validators with no matching reward contribute 0. Drops the now-unused `len != 1` and `denom != c.denom` branches.

The metric shape is unchanged — still `manifest_tokenomics_fees{amount=<umfx total>, denom="umfx"}` — so **no netdata / vmalert / dashboard changes are needed**; the umfx series resumes with continuous semantics.

## Tests

Adds a table-driven unit test for the per-validator extraction (first test file in the repo):
- `{umfx, upwr}` → returns the umfx amount (regression for this bug)
- reversed order `{upwr, umfx}` → still returns umfx
- single `umfx` → unchanged
- fractional umfx → truncated to integer
- single `upwr` → contributes 0 (no error)
- empty rewards → contributes 0
- invalid amount string → errors

Verified with `go build`, `go vet`, `go test`, and `gofmt` all under `-tags manifest_node_exporter`.

## Deploy notes (not in this PR)

Rebuild with `-tags manifest_node_exporter`, cut a release, redeploy to public mainnet validators, restart netdata. The 2026-06-01→fix window stays as a known gap in stored data (the source emitted 0 too; not auto-recoverable). `locked_fees` should snap back to ~the pre-outage value after deploy.

Longer-term (separate task): source locked-fees from yaci, which already indexes tx fees per-denom.

Fixes ENG-283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)