### PR TITLE
ci: bump Go toolchain to 1.26.4 to clear stdlib CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: '1.24.6'
+  GO_VERSION: '1.26.4'
   GORELEASER_VERSION: 'v2.9.0'
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GO_VERSION: '1.24.6'
+  GO_VERSION: '1.26.4'
   GORELEASER_VERSION: 'v2.9.0'
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ format: ## Run formatter (goimports)
 .PHONY: format
 
 #### GOVULNCHECK ####
-govulncheck_version=v1.1.3
+govulncheck_version=v1.3.0
 
 govulncheck: ## Run govulncheck
 	@echo "--> Running govulncheck"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/manifest-network/manifest-node-exporter
 
-go 1.24.6
+go 1.26.4
 
 require (
 	cosmossdk.io/api v0.9.2


### PR DESCRIPTION
## Problem

The `Security (govulncheck)` CI gate is failing on **25 reachable Go standard-library CVEs** — not third-party packages. They are all reported against the pinned **go1.24.6** toolchain:

`crypto/tls`, `crypto/x509`, `encoding/asn1`, `encoding/pem`, `html/template`, `net`, `net/http`, `net/textproto`, `net/url`, `os`.

**go1.24 is end-of-life**, and several of these fixes (e.g. `html/template`, `net`, `net/textproto`, `os`) were only ever shipped on the **go1.25+** line and never backported to 1.24.x — so no go1.24 patch can ever make this gate pass.

## Fix

- Bump the Go toolchain to the latest stable **go1.26.4** in `go.mod` and both workflows (`ci.yml`, `release.yml`). This is the toolchain that compiles the shipped binaries, so the released artifacts also get the patched stdlib.
- Bump **govulncheck `v1.1.3` → `v1.3.0`** in the `Makefile`. `v1.1.3` transitively pulls `golang.org/x/tools v0.23.0`, which **fails to compile under go1.26** (`invalid array length` in `tokeninternal`). Without this bump, the gate would just swap a vuln failure for an install-step failure.

## Verification (local, under go1.26.4)

- `go build -tags manifest_node_exporter ./...` → OK
- `go vet -tags manifest_node_exporter ./...` → OK
- `go test -tags manifest_node_exporter ./...` → OK
- `make govulncheck` → **"Your code is affected by 0 vulnerabilities"**, exit 0

The remaining advisories (4 in imported packages, 8 in required modules) are **not called** by this code, so they don't affect the gate. They can be addressed separately via dependency bumps if desired.

## Note

This unblocks all branches/PRs (the gate was failing repo-wide, e.g. on #20). #20 will go green once it's rebased onto `main` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)